### PR TITLE
Reusing notification structure found in unidos contra corrupção fork …

### DIFF
--- a/src/ej/settings/__init__.py
+++ b/src/ej/settings/__init__.py
@@ -5,6 +5,7 @@ from .celery import CeleryConf
 from .constance import ConstanceConf
 from .log import LoggingConf
 from .middleware import MiddlewareConf
+from .notifications import NotificationsConf
 from .options import EjOptions
 from .paths import PathsConf
 from .security import SecurityConf
@@ -17,6 +18,7 @@ log = logging.getLogger('ej')
 class Conf(ThemesConf,
            ConstanceConf,
            MiddlewareConf,
+           NotificationsConf,
            CeleryConf,
            SecurityConf,
            LoggingConf,

--- a/src/ej/settings/apps.py
+++ b/src/ej/settings/apps.py
@@ -9,6 +9,9 @@ class InstalledAppsConf(Base, EjOptions):
         'ej_reports',
         'ej_clusters',
 
+        # Notifications
+        'ej_notifications',
+
         # Conversations
         'ej_boards',
         'ej_conversations',
@@ -40,6 +43,7 @@ class InstalledAppsConf(Base, EjOptions):
         'corsheaders',
         'constance',
         'constance.backends.database',
+        'push_notifications',
     ]
 
     def get_django_contrib_apps(self):

--- a/src/ej/settings/notifications.py
+++ b/src/ej/settings/notifications.py
@@ -1,0 +1,7 @@
+from boogie.configurations import Conf
+
+
+class NotificationsConf(Conf):
+    PUSH_NOTIFICATIONS_SETTINGS = {
+        "FCM_API_KEY": "",
+    }

--- a/src/ej_notifications/admin.py
+++ b/src/ej_notifications/admin.py
@@ -1,0 +1,7 @@
+from django.contrib import admin
+
+from .models import Notification, Channel, Message
+
+admin.site.register(Notification)
+admin.site.register(Channel)
+admin.site.register(Message)

--- a/src/ej_notifications/models/__init__.py
+++ b/src/ej_notifications/models/__init__.py
@@ -1,0 +1,3 @@
+from .channels import Channel, Purpose
+from .messages import Message
+from .notifications import Notification

--- a/src/ej_notifications/models/channels.py
+++ b/src/ej_notifications/models/channels.py
@@ -1,0 +1,37 @@
+from django.db import models
+from boogie.rest import rest_api
+from autoslug import AutoSlugField
+from django.utils.translation import ugettext_lazy as _
+from boogie import IntEnum
+from boogie.fields import EnumField
+
+from ej_users.models import User
+
+
+class Purpose(IntEnum):
+    GENERAL = 0, _('General')
+    CONVERSATION = 1, _('Conversation')
+    GROUP = 2, _('Group')
+    TROPHIES = 3, _('Trophies')
+    ADMIN = 4, _('Admin')
+    APPROVED_NOTIFICATIONS = 5, _('Approved Notifications')
+    DISAPPROVED_NOTIFICATIONS = 6, _('Disapproved Notifications')
+
+
+@rest_api(
+    ['name', 'users', 'owner', 'purpose', 'created_at'],
+    lookup_field='slug',
+)
+class Channel(models.Model):
+    name = models.CharField(max_length=100)
+    users = models.ManyToManyField(User, blank=True)
+    purpose = EnumField(Purpose, _('Purpose'), default=Purpose.GENERAL)
+    created_at = models.DateTimeField(null=True, auto_now_add=True)
+    owner = models.ForeignKey(User, on_delete=models.CASCADE, null=True, related_name="channel_owner")
+    slug = AutoSlugField(
+        unique=True,
+        populate_from='title',
+    )
+
+    class Meta:
+        ordering = ['slug']

--- a/src/ej_notifications/models/messages.py
+++ b/src/ej_notifications/models/messages.py
@@ -1,0 +1,66 @@
+from django.db import models
+from django.db.models.signals import post_save
+from django.dispatch import receiver
+
+from push_notifications.models import GCMDevice
+from ej_notifications.models import Channel
+from ej_profiles.models import Setting
+
+
+class Message(models.Model):
+    title = models.CharField(max_length=100)
+    body = models.CharField(max_length=250)
+    link = models.CharField(max_length=250, blank=True)
+    channel = models.ForeignKey(Channel, on_delete=models.CASCADE, null=True)
+    created_at = models.DateTimeField(null=True, auto_now_add=True)
+    status = models.CharField(max_length=100, default="pending")
+    target = models.IntegerField(blank=True, default=0)
+
+    class Meta:
+        ordering = ['title']
+
+
+# This sends notifications after saving object
+@receiver(post_save, sender=Message)
+def generate_notifications(sender, instance, created, **kwargs):
+    if created:
+        # avoid circular import
+        from ej_notifications.models import Notification
+        channel_id = instance.channel.id
+        channel = Channel.objects.get(id=channel_id)
+        for user in channel.users.all():
+            Notification.objects.create(receiver=user, channel=channel, message=instance)
+
+
+@receiver(post_save, sender=Message)
+def send_admin_fcm_message(sender, instance, created, **kwargs):
+    if created:
+        channel_id = instance.channel.id
+        channel = Channel.objects.get(id=channel_id)
+        users_to_send = []
+        if channel.purpose == 'admin':
+            for user in channel.users.all():
+                setting = Setting.objects.get(owner_id=user.id)
+                if (setting.admin_notifications):
+                    users_to_send.append(user)
+            fcm_devices = GCMDevice.objects.filter(cloud_message_type="FCM", user__in=users_to_send)
+            fcm_devices.send_message("", extra={"title": instance.title, "body": instance.body,
+                                     "icon": "https://i.imgur.com/D1wzP69.png", "click_action": instance.link})
+
+
+@receiver(post_save, sender=Message)
+def send_conversation_fcm_message(sender, instance, created, **kwargs):
+    if created:
+        channel_id = instance.channel.id
+        channel = Channel.objects.get(id=channel_id)
+        users_to_send = []
+        url = "https://localhost:9000/" + str(instance.target) + "?notification=true"
+        if "conversation" in channel.purpose:
+            for user in channel.users.all():
+
+                setting = Setting.objects.get(owner_id=user.id)
+                if setting.conversation_notifications:
+                    users_to_send.append(user)
+            fcm_devices = GCMDevice.objects.filter(cloud_message_type="FCM", user__in=users_to_send)
+            fcm_devices.send_message("", extra={"title": instance.title, "body": instance.body,
+                                     "icon": "https://i.imgur.com/D1wzP69.png", "click_action": url})

--- a/src/ej_notifications/models/notifications.py
+++ b/src/ej_notifications/models/notifications.py
@@ -1,0 +1,13 @@
+from django.db import models
+
+from ej_users.models import User
+from ej_notifications.models import Channel
+from ej_notifications.models import Message
+
+
+class Notification(models.Model):
+    receiver = models.ForeignKey(User, on_delete=models.CASCADE, related_name="receiver")
+    read = models.BooleanField(default=False)
+    message = models.ForeignKey(Message, on_delete=models.CASCADE, null=True)
+    created_at = models.DateTimeField(null=True, auto_now_add=True)
+    channel = models.ForeignKey(Channel, on_delete=models.CASCADE)

--- a/src/ej_notifications/routes.py
+++ b/src/ej_notifications/routes.py
@@ -1,29 +1,53 @@
 from django.utils.translation import ugettext_lazy as _
-
 from boogie.router import Router
+
+from ej_notifications.models import Notification
 
 app_name = 'ej_notifications'
 urlpatterns = Router(
     login=True,
-    template=['ej_notifications/{name}.jinja2', 'generic.jinja2']
+    template=['ej_notifications/{name}.jinja2', 'generic.jinja2'],
+    models={
+        'notification': Notification,
+    },
+    lookup_field={
+        'notification': 'id',
+    },
+    object='notification',
 )
+notification_url = f'<model:notification>/'
 
 
 @urlpatterns.route()
 def index(request):
     user = request.user
+    notifications = Notification.objects.filter(receiver__id=user.id, read=False).order_by("-created_at")
+
     return {
         'content_title': _('List of notifications'),
         'user': user,
-        'notifications': ['hello', 'world'],
-        # 'notifications': user.notifications.unseen(),
+        'notifications': notifications,
     }
+
+
+# criação de notificação: Receiver (Usuário),  Canal, Mensagem, Salva uma notificação(Usar um forms!)
+@urlpatterns.route('create/')
+def create(request):
+    return {}
 
 
 @urlpatterns.route('history/')
 def clusters(request):
     user = request.user
+    notifications = Notification.objects.filter(receiver__id=user.id, read=True).order_by("-created_at")
     return {
         'user': user,
-        # 'notifications': user.notifications.seen(),
+        'notifications': notifications,
     }
+
+
+@urlpatterns.route('read/' + notification_url)
+def read_notification(request, notification):
+    notification.read = True
+    notification.save()
+    return {'message': notification.message}

--- a/src/ej_notifications/routes/channels.py
+++ b/src/ej_notifications/routes/channels.py
@@ -1,0 +1,18 @@
+from boogie.router import Router
+
+from ej_notifications.models import Channel
+
+app_name = 'ej_notifications'
+urlpatterns = Router(
+    login=True,
+    template=['ej_notifications/{name}.jinja2', 'generic.jinja2'],
+    models={
+        'channel': Channel,
+    },
+    lookup_field={
+        'channel': 'slug',
+    },
+    lookup_type='slug',
+    object='channel',
+)
+notification_url = f'<model:channel>/'


### PR DESCRIPTION
# Descrição
Nesse pr estão sendo adaptados os apps utilizados no mecanismo de notificações criados no fork [unidos contra a corrupção](https://github.com/unidoscontraacorrupcao/ej-server/tree/develop/src) 

Principais problemas encontrados até agora:
- Não é utilizada a arquitetura padrão do ej 
- Não existem testes desses apps
- Ícones hospedados no imgur sendo chamados de dentro do código e urls também (ej_messages.models)

Devido aos problemas e também para não puxar uma quantidade muito grande commits para o repositório, dificultando o merge, deletei a última versão dessa branch e estou criando novamente, usando o código do unidos contra a corrupção como base porém implementando adaptações para o ej.

## Issues Relacionadas
 resolves #398 

## Checklist  
- [ ] Os commits seguem o padrão do projeto (Flake8 e afins)
- [ ] Os testes estão passando e cobrem as mudanças 
