### PR TITLE
Fixing create conversation in board bug and templates references issues

### DIFF
--- a/src/ej_boards/routes.py
+++ b/src/ej_boards/routes.py
@@ -80,7 +80,7 @@ def edit(request, board):
     }
 
 
-@urlpatterns.route('<model:board>/conversations/')
+@urlpatterns.route('<model:board>/conversations/', template='ej_conversations/list.jinja2')
 def conversation_list(request, board):
     user = request.user
     conversations = board.conversations.all()
@@ -88,15 +88,17 @@ def conversation_list(request, board):
     boards = []
     if user == board_user:
         boards = board_user.boards.all()
-
+        user_is_owner = True
+    else:
+        user_is_owner = False
     return {
+        'can_add_conversation': user_is_owner,
+        'create_url': reverse('boards:create-conversation', kwargs={'board': board}),
         'conversations': conversations,
         'boards': boards,
         'board': board,
-        'can_add_conversation': board_user == user,
         'is_a_board': True,
-        'owns_board': user == board.owner,
-        'create_url': reverse('boards:create-conversation', kwargs={'board': board}),
+        'owns_board': user_is_owner,
         'title': _("%s' conversations") % board.title,
         'subtitle': _("These are %s's conversations. Contribute to them too") % board.title,
     }

--- a/src/ej_conversations/jinja2/ej_conversations/list.jinja2
+++ b/src/ej_conversations/jinja2/ej_conversations/list.jinja2
@@ -1,5 +1,4 @@
 {% extends 'base.jinja2' %}
-{% from 'ej_conversations/components/conversation-list.jinja2' import conversation_list with context %}
 
 {% block content %}
     {% if can_add_conversation and create_url %}

--- a/src/ej_conversations/routes/admin.py
+++ b/src/ej_conversations/routes/admin.py
@@ -10,7 +10,6 @@ from .. import forms, models
 @urlpatterns.route('add/', login=True, perms=['ej.can_add_promoted_conversation'])
 def create(request):
     form = forms.ConversationForm(request.POST or None)
-
     if request.method == 'POST' and form.is_valid():
         with transaction.atomic():
             conversation = form.save_all(

--- a/src/ej_profiles/jinja2/ej_profiles/favorite-conversations.jinja2
+++ b/src/ej_profiles/jinja2/ej_profiles/favorite-conversations.jinja2
@@ -7,7 +7,7 @@
     {% else %}
         <div class="CenteredContainer">
             <h1>{% trans %}Favorite conversations{% endtrans %}</h1>
-            <p>{% trans %}You have not have any favorite conversations!{% endtrans %}</p>
+            <p>{% trans %}You do not have any favorite conversations!{% endtrans %}</p>
         </div>
     {% endif %}
 {% endblock %}

--- a/src/ej_profiles/routes.py
+++ b/src/ej_profiles/routes.py
@@ -65,7 +65,7 @@ def edit(request):
     }
 
 
-@urlpatterns.route('conversations/', template='ej_conversations/conversations-list.jinja2')
+@urlpatterns.route('conversations/', template='ej_conversations/list.jinja2')
 def conversations_list(request):
     user = request.user
     boards = user.boards.all()


### PR DESCRIPTION
# Descrição

Alterações feitas nesse PR:
- Correção do template utilizado na rota /profile/conversations (essa rota exibe todas as conversas de todos os boards que pertencem a aquele usuário)
- Retirada da importação de conversation-list do template list, que não estava sendo utilizado
- Correção de tradução no template de conversas favoritas
- Correção do template de listagem de conversas no board do usuário, habilitando novamente o botão de criação de conversa no board

## Issues Relacionadas
 resolves: #427 

## Checklist  
- [ ] Os commits seguem o padrão do projeto (Flake8 e afins)
- [ ] Os testes estão passando e cobrem as mudanças 
