### PR TITLE
[REVIEW] Changes Permanent link icon and messages

### DIFF
--- a/src/ej_conversations/forms.py
+++ b/src/ej_conversations/forms.py
@@ -16,7 +16,7 @@ class ConversationForm(forms.ModelForm):
         super().__init__(*args, **kwargs)
         self.set_placeholder('tags', _('Tags, separated by commas'))
         self.set_placeholder('text', _('Type here the question for your research'))
-        self.set_placeholder('title', _('A short description about this conversation.'))
+        self.set_placeholder('title', _('Permanent link.'))
         self.fields['text'].widget.attrs.update({
             'onfocus': "this.style.height = (this.scrollHeight) + 'px'",
             'onkeyup': "this.style.height = (this.scrollHeight) + 'px'",

--- a/src/ej_conversations/jinja2/ej_conversations/create.jinja2
+++ b/src/ej_conversations/jinja2/ej_conversations/create.jinja2
@@ -61,7 +61,7 @@
                 <div class="ConversationDetail-arrow"></div>
             </div>
 
-            <div class="ConversationField"><i class="fa fa-heading"></i>{{ form.title }}</div>
+            <div class="ConversationField"><i class="fa fa-link"></i>{{ form.title }}</div>
             <input type="hidden" name="comments_count" value="5">
 
             <div class="Moderate-comments">


### PR DESCRIPTION
# Descrição

  Altera o campo de descrição rápida para de link permanente na tela de criação de conversas.

## Issues Relacionadas
  #504 

## Checklist  
- [ ] Os commits seguem o padrão do projeto (Flake8 e afins)
- [ ] Os testes estão passando e cobrem as mudanças 

## Imagens/Comentários
Com a atualização:
![image](https://user-images.githubusercontent.com/20361663/46480081-dc672780-c7c6-11e8-9246-4e5753007403.png)
