### PR TITLE
[REVIEW] Fix EnumField bug and stereotype duplicated select option

### DIFF
--- a/lib/assets/js/dynamic-form.js
+++ b/lib/assets/js/dynamic-form.js
@@ -7,9 +7,17 @@ function cloneForm(element, preserve) {
     
     updateFormIndex(cloned, totalForms);
 
+    // cleaning all data from form used to make the clone
+    cloned.find(".errorlist").remove();
+    cloned.find("select").each(function() {
+        $(this).val(null)
+    })
+    
     cloned.appendTo(".votes_form_class");
     
     var forms = $(".form-row");
+
+
     updateFormsRemoveBtns(forms);
     preserveSelectedOptions(forms);
 }

--- a/src/ej_clusters/forms.py
+++ b/src/ej_clusters/forms.py
@@ -34,7 +34,13 @@ class StereotypeVoteForm(ModelForm):
         self.fields['comment'].widget.attrs = {'class': 'comment_select'}
 
 
-StereotypeVoteFormSet = modelformset_factory(
+StereotypeVoteCreateFormSet = modelformset_factory(
     StereotypeVote,
     form=StereotypeVoteForm,
+)
+
+StereotypeVoteEditFormSet = modelformset_factory(
+    StereotypeVote,
+    form=StereotypeVoteForm,
+    extra=0,
 )

--- a/src/ej_clusters/routes.py
+++ b/src/ej_clusters/routes.py
@@ -7,7 +7,7 @@ from hyperpython.components import html_list, html_table
 
 from boogie.router import Router
 from boogie.rules import proxy_seq
-from ej_clusters.forms import StereotypeForm, StereotypeVoteFormSet
+from ej_clusters.forms import StereotypeForm, StereotypeVoteCreateFormSet, StereotypeVoteEditFormSet
 from ej_conversations.models import Conversation, Choice, Comment
 from .models import Stereotype, Cluster, StereotypeVote, Clusterization
 
@@ -134,7 +134,7 @@ def list_cluster(request):
 def create_stereotype_context(request, conversation, board=None):
     if request.method == 'POST':
         stereotype_form = StereotypeForm(request.POST, conversation=conversation)
-        votes_formset = StereotypeVoteFormSet(request.POST)
+        votes_formset = StereotypeVoteCreateFormSet(request.POST)
 
         if stereotype_form.is_valid() and votes_formset.is_valid():
             stereotype = stereotype_form.save(commit=False)
@@ -153,7 +153,7 @@ def create_stereotype_context(request, conversation, board=None):
 
     else:
         stereotype_form = StereotypeForm(conversation=conversation)
-        votes_formset = StereotypeVoteFormSet(queryset=StereotypeVote.objects.none())
+        votes_formset = StereotypeVoteCreateFormSet(queryset=StereotypeVote.objects.none())
 
     filtered_comments = Comment.objects.filter(conversation=conversation)
     for form in votes_formset:
@@ -171,7 +171,7 @@ def edit_stereotype_context(request, conversation, stereotype, board=None):
     if request.method == 'POST':
         stereotype_form = StereotypeForm(request.POST, conversation=conversation, instance=stereotype)
         votes = StereotypeVote.objects.filter(author=stereotype)
-        votes_formset = StereotypeVoteFormSet(request.POST, queryset=votes)
+        votes_formset = StereotypeVoteEditFormSet(request.POST, queryset=votes)
 
         if stereotype_form.is_valid() and votes_formset.is_valid():
             stereotype = stereotype_form.save()
@@ -182,7 +182,7 @@ def edit_stereotype_context(request, conversation, stereotype, board=None):
     else:
         stereotype_form = StereotypeForm(conversation=conversation, instance=stereotype)
         votes = StereotypeVote.objects.filter(author=stereotype)
-        votes_formset = StereotypeVoteFormSet(queryset=votes)
+        votes_formset = StereotypeVoteEditFormSet(queryset=votes)
 
         filtered_comments = Comment.objects.filter(conversation=conversation)
         for form in votes_formset:


### PR DESCRIPTION
# Descrição
  Corrigido bug que deixa selecionado a opção do ultimo stereotype ao adicionar um novo e com a versão 0.9.3 do django-boogie corrigido o bug que a opção selecionada não aparecia em todos os EnumField.

## Issues Relacionadas
  resolves: #537

## Checklist  
- [x] Os commits seguem o padrão do projeto (Flake8 e afins)
- [x] Os testes estão passando e cobrem as mudanças 
- [x] Marcou no título do pull request se ele é work in progress [WIP] ou se está pronto para revisão [REVIEW]

## Imagens/Comentários
  <!--Insira imagens(prints ou gifs) com comentários sobre as mudanças (caso seja frontend)-->
