### PR TITLE
[REVIEW] I549 Texto de rejeição de comentário aprovado

### DIFF
--- a/src/ej_conversations/roles.py
+++ b/src/ej_conversations/roles.py
@@ -109,9 +109,10 @@ def comment_list_item(comment, **kwargs):
     """
 
     rejection_reason = comment.rejection_reason
-    if rejection_reason in dict(models.Comment.REJECTION_REASON):
+    if rejection_reason in dict(models.Comment.REJECTION_REASON) and comment.status == comment.STATUS.rejected:
         rejection_reason = dict(models.Comment.REJECTION_REASON)[comment.rejection_reason]
-
+    else:
+        rejection_reason = None
     return {
         'rejection_reasons': dict(models.Comment.REJECTION_REASON),
         'comment': comment,

--- a/src/ej_conversations/routes/admin.py
+++ b/src/ej_conversations/routes/admin.py
@@ -72,8 +72,12 @@ def moderate_context(request, conversation):
     comments = []
     if request.method == 'POST':
         comment = models.Comment.objects.get(id=request.POST['comment'])
-        comment.status = comment.STATUS.approved if request.POST['vote'] == 'approve' else comment.STATUS.rejected
-        comment.rejection_reason = request.POST['rejection_reason']
+        if request.POST['vote'] == 'approve':
+            comment.status = comment.STATUS.approved
+            comment.rejection_reason = ''
+        else:
+            comment.status = comment.STATUS.rejected
+            comment.rejection_reason = request.POST['rejection_reason']
         comment.save()
 
     status = request.GET.get('status')

--- a/src/ej_conversations/routes/admin.py
+++ b/src/ej_conversations/routes/admin.py
@@ -1,10 +1,13 @@
 from django.db import transaction
-from django.http import Http404
+from django.http import Http404, HttpResponseServerError
 from django.shortcuts import redirect
+from logging import getLogger
 
 from ej_boards.models import BoardSubscription
 from . import urlpatterns, conversation_url
 from .. import forms, models
+
+log = getLogger('ej')
 
 
 @urlpatterns.route('add/', login=True, perms=['ej.can_add_promoted_conversation'])
@@ -75,11 +78,14 @@ def moderate_context(request, conversation):
         if request.POST['vote'] == 'approve':
             comment.status = comment.STATUS.approved
             comment.rejection_reason = ''
-        else:
+        elif request.POST['vote'] == 'disapprove':
             comment.status = comment.STATUS.rejected
             comment.rejection_reason = request.POST['rejection_reason']
+        else:
+            # User is probably trying to something nasty ;)
+            log.warning(f'user {request.user.id} sent invalid POST request: {request.POST}')
+            return HttpResponseServerError('invalid action')
         comment.save()
-
     status = request.GET.get('status')
     status = 'pending' if status not in ['pending', 'approved', 'rejected'] else status
     for comment in models.Comment.objects.filter(conversation=conversation, status=status):

--- a/src/ej_conversations/tests/test_views.py
+++ b/src/ej_conversations/tests/test_views.py
@@ -1,11 +1,12 @@
 import pytest
 from django.contrib.auth.models import AnonymousUser
 from pytest import raises
+from django.http import HttpResponseServerError, Http404
 
 from ej_conversations import create_conversation
 from ej_conversations.models import Comment, FavoriteConversation
 from ej_conversations.models.utils import votes_counter
-from ej_conversations.routes import conversations, comments
+from ej_conversations.routes import conversations, comments, admin
 from ej_users.models import User
 
 
@@ -99,3 +100,41 @@ class TestConversationComments:
     def test_user_can_get_detail_of_a_comment(self, conversation, comment):
         ctx = comments.comment_detail(conversation, comment)
         assert ctx['comment'] is comment
+
+
+class TestAdminViews:
+    def test_author_can_moderate_conversation_approving_comment(self, rf, conversation):
+        other = User.objects.create_user('email@email.br', 'pass')
+        comment = conversation.create_comment(other, 'aa', check_limits=False)
+        assert comment.status == comment.STATUS.pending
+        request = rf.post('', {'comment': comment.id, 'vote': 'approve'})
+        request.user = User.objects.get(email='email@server.com')
+        admin.moderate(request, conversation)
+        comment.refresh_from_db()
+        assert comment.status == comment.STATUS.approved
+
+    def test_author_can_moderate_conversation_rejecting_comment(self, rf, conversation):
+        other = User.objects.create_user('email@email.br', 'pass')
+        comment = conversation.create_comment(other, 'aa', check_limits=False)
+        assert comment.status == comment.STATUS.pending
+        request = rf.post('', {'comment': comment.id, 'vote': 'disapprove', 'rejection_reason': 'offensive_language'})
+        request.user = User.objects.get(email='email@server.com')
+        admin.moderate(request, conversation)
+        comment.refresh_from_db()
+        assert comment.status == comment.STATUS.rejected
+
+    def test_author_try_moderate_invalid_vote(self, rf, conversation):
+        other = User.objects.create_user('email@email.br', 'pass')
+        comment = conversation.create_comment(other, 'aa', check_limits=False)
+        request = rf.post('', {'comment': comment.id, 'vote': 'other', 'rejection_reason': 'offensive_language'})
+        request.user = User.objects.get(email='email@server.com')
+        response = admin.moderate(request, conversation)
+        assert isinstance(response, HttpResponseServerError)
+
+    def test_author_try_moderate_unpromoted_conversation(self, rf, conversation):
+        request = rf.get('')
+        request.user = User.objects.get(email='email@server.com')
+        conversation.is_promoted = False
+        conversation.save()
+        with raises(Http404):
+            admin.moderate(request, conversation)


### PR DESCRIPTION
# Descrição
 
Fiz alterações em dois lugares do código para que um comentário aprovado não tenha motivo de rejeição:
- Só exibir na página do usuário o motivo de rejeição se o status do comentário de fato seja rejeitado
- Quando um comentário é aprovado possui o motivo de rejeição alterado para None

Quando são 
## Issues Relacionadas
resolves: #549 

## Checklist  
- [x] Os commits seguem o padrão do projeto (Flake8 e afins)
- [x] Os testes estão passando e cobrem as mudanças 
- [x] Marcou no título do pull request se ele é work in progress [WIP] ou se está pronto para revisão [REVIEW]