### PR TITLE
[REVIEW] Imagem carregada no perfil deveria ter recorte redondo

### DIFF
--- a/lib/scss/6_components/_profile.scss
+++ b/lib/scss/6_components/_profile.scss
@@ -162,7 +162,7 @@ $profile-label-clear-color: #30BFD3 !default;
         height: $profile-image-size;
         // FIXME See if it will necessary
         // border: $spacing-unit-small solid $color-green;
-        // border-radius: 50ch;
+        border-radius: $spacing-unit + $spacing-unit-tiny + $spacing-unit-huge;
     }
     &-rocket {
         text-align: center;

--- a/src/ej_profiles/jinja2/ej_profiles/edit.jinja2
+++ b/src/ej_profiles/jinja2/ej_profiles/edit.jinja2
@@ -11,7 +11,7 @@
             {{ form.as_p() }}
            <label for="id_image" class="FormItem CustomFileInput">
                <div>
-                   {{ _('Choose a file!') }}
+                   {{ _('Choose a file') }}
                </div>
                <div id="image-filename">
                    {{ _('No file chosen') }}

--- a/src/ej_profiles/jinja2/ej_profiles/edit.jinja2
+++ b/src/ej_profiles/jinja2/ej_profiles/edit.jinja2
@@ -11,7 +11,7 @@
             {{ form.as_p() }}
            <label for="id_image" class="FormItem CustomFileInput">
                <div>
-                   {{ _('Choose a file') }}
+                   {{ _('Choose a file!') }}
                </div>
                <div id="image-filename">
                    {{ _('No file chosen') }}


### PR DESCRIPTION
# Descrição
 A imagem do perfil deve ficar de acordo com a tela no invision, então eu incluir um border-radius nela e então ela ficou redonda.

## Issues Relacionadas
resolves: #474 

## Checklist  
- [ ] Os commits seguem o padrão do projeto (Flake8 e afins)
- [ ] Os testes estão passando e cobrem as mudanças 
- [ ] Marcou no título do pull request se ele é work in progress [WIP] ou se está pronto para revisão [REVIEW]

## Imagens/Comentários
 Estava assim : 
![captura de tela de 2018-10-24 09-14-33](https://user-images.githubusercontent.com/15165117/47429656-6de60b80-d76d-11e8-9e31-7808db27f7ae.png)
E deveria estar assim : 
![captura de tela de 2018-10-24 09-15-30](https://user-images.githubusercontent.com/15165117/47429680-78a0a080-d76d-11e8-8d4b-8466aa7dfb81.png)
Com as alterações está assim : 
![captura de tela de 2018-10-24 09-25-19](https://user-images.githubusercontent.com/15165117/47430236-2e202380-d76f-11e8-8cd6-cfb106aa9000.png)

