### PR TITLE
[REVIEW] Correção da edição de conversa que não estava salvando

### DIFF
--- a/src/ej_conversations/jinja2/ej_conversations/edit.jinja2
+++ b/src/ej_conversations/jinja2/ej_conversations/edit.jinja2
@@ -35,9 +35,7 @@
 
                   <p><textarea onfocus="this.style.height = (this.scrollHeight) + 'px'" onkeyup="this.style.height = (this.scrollHeight) + 'px'" class="Conversation-edit-field" name="text" required id="id_text">{{ conversation.text }}</textarea></p>
 
-                  <div class="Conversation-edit">
-                    <b>{{_('Edit Conversation') }}</b>
-                  </div>
+                  <input type="hidden" name="comments_count" value="0">
               </div>
 
               <div class="ConversationDetail-arrow"></div>


### PR DESCRIPTION
# Descrição
   Correção do erro ao editar uma conversa e remoção do botão de editar que deveria aparecer apenas na página de moderação.

## Issues Relacionadas
resolves: #614 

## Checklist  
- [x] Os commits seguem o padrão do projeto (Flake8 e afins)
- [x] Os testes estão passando e cobrem as mudanças 
- [x] Marcou no título do pull request se ele é work in progress [WIP] ou se está pronto para revisão [REVIEW]

