### PR TITLE
[REVIEW] Botão de retorno da conversa sempre volta para a board

### DIFF
--- a/src/ej/templates/jinja2/components/generic/page_header.jinja2
+++ b/src/ej/templates/jinja2/components/generic/page_header.jinja2
@@ -61,10 +61,15 @@
     {% endblock %}
     <nav class="Header-topNav">
         {% if request.path not in ['/start/', '/conversations/', '/home/'] %}
-            <a title="{{ _('Back') }}" class="Header-topIcon" onclick="history.back()">
-                <i class="fa fa-chevron-left"></i>
-            </a>
-
+            {% if not '/conversations/' in request.path %}
+                <a title="{{ _('Back') }}" class="Header-topIcon" onclick="history.back()">
+                    <i class="fa fa-chevron-left"></i>
+                </a>
+            {% else %}
+                <a href="{{request.path.split('/conversations/')[0] + '/conversations/'}}" title="{{ _('Back') }}" class="Header-topIcon">
+                    <i class="fa fa-chevron-left"></i>
+                </a>
+            {% endif %}
             {% call link(href='/', class="Header-ejLogo") %}
                 <img src="/static/img/logo/logo.svg" alt="{{_('Site logo')}}">
             {% endcall %}


### PR DESCRIPTION
# Descrição

 Foi modificado para que o botão de retorno voltasse para a board que a conversa pertence, mesmo que o usuário não tenha vindo dela.

## Issues Relacionadas
resolves: #622 

## Checklist  
- [x] Os commits seguem o padrão do projeto (Flake8 e afins)
- [x] Os testes estão passando e cobrem as mudanças 
- [x] Marcou no título do pull request se ele é work in progress [WIP] ou se está pronto para revisão [REVIEW]

