### PR TITLE
[REVIEW] Mensagem de erro errada ao tentar comentar com um usuário não logado

### DIFF
--- a/src/ej_boards/tests/test_routes.py
+++ b/src/ej_boards/tests/test_routes.py
@@ -107,7 +107,7 @@ class TestBoardConversationRoutes(ConversationRecipes):
         board.add_conversation(conversation)
         response = routes.conversation_detail(request, board, conversation)
         assert response['conversation'] == conversation
-        assert response['can_view_comment']
+        assert response['can_comment']
         assert response['can_edit']
 
     def test_conversation_detail_post_comment(self, rf, db, board, conversation):
@@ -120,7 +120,7 @@ class TestBoardConversationRoutes(ConversationRecipes):
         board.add_conversation(conversation)
         response = routes.conversation_detail(request, board, conversation)
         assert response['conversation'] == conversation
-        assert response['can_view_comment']
+        assert response['can_comment']
         assert response['can_edit']
         assert Comment.objects.filter(author=user)[0].content == 'test comment'
 
@@ -135,7 +135,7 @@ class TestBoardConversationRoutes(ConversationRecipes):
         board.add_conversation(conversation)
         response = routes.conversation_detail(request, board, conversation)
         assert response['conversation'] == conversation
-        assert response['can_view_comment']
+        assert response['can_comment']
         assert response['can_edit']
         assert votes_counter(comment) == 1
 

--- a/src/ej_conversations/jinja2/ej/role/comment-form.jinja2
+++ b/src/ej_conversations/jinja2/ej/role/comment-form.jinja2
@@ -28,7 +28,7 @@
     <h1>{% trans %}Leave your comment{% endtrans %}</h1>
         <p>{{ _('You still have {n} available comments').format(n=comments_left) }}</p>
         {{ comment_form(csrf_input, comment_content) }}
-    {% elif comments_left == 0 %}
+    {% elif can_comment and comments_left == 0 %}
         <div class="CommentForm-toast">
             <h3>{% trans %}Ooops!{% endtrans %}</h3>
             <p>{% trans %}You reached the limit of comments in this conversation.{% endtrans %}</p>

--- a/src/ej_conversations/jinja2/ej_conversations/detail.jinja2
+++ b/src/ej_conversations/jinja2/ej_conversations/detail.jinja2
@@ -36,7 +36,8 @@
                     <i class="fas fa-plus"></i> {{ _("CREATE COMMENT") }}
                 </button>
             </p>
-            <p>{{ _("{}/{} comment{}.").format(comments_made, max_comments, "" if max_comments == 1 else "s")}}</p>
+            
+            <p>{{ _("{}/{} comment{}.").format(comments_made, max_comments if can_comment else 0, "" if max_comments == 1 else "s")}}</p>
             <p>{{ _("{} waiting moderation.").format(comments_under_moderation)}}</p>
         </div>
     </div>

--- a/src/ej_conversations/roles.py
+++ b/src/ej_conversations/roles.py
@@ -135,10 +135,14 @@ def comment_form(conversation, request=None, comment_content=None, **kwargs):
     """
     user = getattr(request, 'user', None)
     n_comments = rules.compute('ej_conversations.remaining_comments', conversation, user)
+    conversation_url = conversation.get_absolute_url()
+    login = reverse('auth:login')
+    login_anchor = a(_('login'), href=f'{login}?next={conversation_url}')
     return {
         'can_comment': user.has_perm('ej.can_comment', conversation),
         'comments_left': n_comments,
         'user_is_owner': conversation.author == user,
         'csrf_input': csrf_input(request),
         'comment_content': comment_content,
+        'login_anchor': login_anchor,
     }

--- a/src/ej_conversations/routes/conversations.py
+++ b/src/ej_conversations/routes/conversations.py
@@ -87,7 +87,7 @@ def get_conversation_detail_context(request, conversation):
 
         # Permissions and predicates
         'is_favorite': is_favorite,
-        'can_view_comment': user.is_authenticated,
+        'can_comment': user.is_authenticated,
         'can_edit': user.has_perm('ej.can_edit_conversation', conversation),
         'cannot_comment_reason': '',
         'comments_under_moderation': n_comments_under_moderation,


### PR DESCRIPTION
# Descrição
- Alterada lógica no jinja2 de comment-form para exibir o texto correto
- Alterado contexto enviado pela rota conversation-detail
- Alteração de quantidade restantes de comentários quando o usuário está deslogado

## Issues Relacionadas
 resolves: #630 

## Checklist  
- [x] Os commits seguem o padrão do projeto (Flake8 e afins)
- [x] Os testes estão passando e cobrem as mudanças 
- [x] Marcou no título do pull request se ele é work in progress [WIP] ou se está pronto para revisão [REVIEW]

## Imagens/Comentários
  <!--Insira imagens(prints ou gifs) com comentários sobre as mudanças (caso seja frontend)-->
