### PR TITLE
[REVIEW] Correções das urls de conversas dentro de boards

### DIFF
--- a/src/ej_boards/jinja2/ej_boards/board-list.jinja2
+++ b/src/ej_boards/jinja2/ej_boards/board-list.jinja2
@@ -10,7 +10,7 @@
         {# Links #}
         <div class="BoardList-linkList">
             {% for board in boards %}
-                <p>{{ link(_(board.title), href=board.get_absolute_url()) }}</p>
+                <p>{{ link(_(board.title), href=board.get_url('boards:conversation-list')) }}</p>
             {% endfor %}
         </div>
         {% if can_add_board %}

--- a/src/ej_boards/models.py
+++ b/src/ej_boards/models.py
@@ -5,6 +5,7 @@ from django.utils.text import slugify
 from django.utils.translation import ugettext_lazy as _
 from model_utils.models import TimeStampedModel
 
+from ej.utils.url import SafeUrl
 from ej_conversations.models import Conversation, ConversationTag
 from .validators import validate_board_slug
 
@@ -74,6 +75,10 @@ class Board(TimeStampedModel):
         Return True if conversation is present in board.
         """
         return bool(self.board_subscriptions.filter(conversation=conversation))
+
+    def get_url(self, which, **kwargs):
+        kwargs['board'] = self
+        return SafeUrl(which, **kwargs)
 
 
 class BoardSubscription(models.Model):

--- a/src/ej_boards/routes.py
+++ b/src/ej_boards/routes.py
@@ -93,7 +93,7 @@ def conversation_detail(request, board, conversation):
                    perms=['ej.can_edit_conversation:conversation'])
 def conversation_edit(request, board, conversation):
     assure_correct_board(conversation, board)
-    ctx = get_conversation_edit_context(request, conversation)
+    ctx = get_conversation_edit_context(request, conversation, board)
     ctx['board'] = board
     return ctx
 
@@ -109,7 +109,7 @@ def conversation_moderate(request, board, conversation):
                    perms=['ej.can_manage_stereotypes:conversation'])
 def conversation_stereotype_list(board, conversation):
     assure_correct_board(conversation, board)
-    return cluster_routes.stereotype_list(conversation)
+    return cluster_routes.stereotype_list_context(conversation)
 
 
 @urlpatterns.route('<model:board>/conversations/<model:conversation>/stereotypes/add/',

--- a/src/ej_clusters/routes.py
+++ b/src/ej_clusters/routes.py
@@ -73,15 +73,7 @@ def clusterize(conversation):
                    perms=['ej.can_manage_stereotypes:conversation'])
 def stereotype_list(conversation):
     if conversation.is_promoted:
-        clusterization = conversation.get_clusterization(None)
-        stereotypes = () if clusterization is None else clusterization.stereotypes.all()
-        return {
-            'content_title': _('Stereotypes'),
-            'conversation_title': conversation.title,
-            'stereotypes': stereotypes,
-            'stereotype_url': conversation.get_absolute_url() + 'stereotypes/',
-            'conversation_url': conversation.get_absolute_url(),
-        }
+        return stereotype_list_context(conversation)
     else:
         raise Http404
 
@@ -138,6 +130,18 @@ def list_cluster(request):
 #
 # Auxiliary functions
 #
+def stereotype_list_context(conversation):
+    clusterization = conversation.get_clusterization(None)
+    stereotypes = () if clusterization is None else clusterization.stereotypes.all()
+    return {
+        'content_title': _('Stereotypes'),
+        'conversation_title': conversation.title,
+        'stereotypes': stereotypes,
+        'stereotype_url': conversation.get_absolute_url() + 'stereotypes/',
+        'conversation_url': conversation.get_absolute_url(),
+    }
+
+
 def create_stereotype_context(request, conversation):
     if request.method == 'POST':
         stereotype_form = StereotypeForm(request.POST, owner=request.user)

--- a/src/ej_clusters/routes.py
+++ b/src/ej_clusters/routes.py
@@ -72,15 +72,18 @@ def clusterize(conversation):
 @urlpatterns.route('conversations/<model:conversation>/stereotypes/',
                    perms=['ej.can_manage_stereotypes:conversation'])
 def stereotype_list(conversation):
-    clusterization = conversation.get_clusterization(None)
-    stereotypes = () if clusterization is None else clusterization.stereotypes.all()
-    return {
-        'content_title': _('Stereotypes'),
-        'conversation_title': conversation.title,
-        'stereotypes': stereotypes,
-        'stereotype_url': conversation.get_absolute_url() + 'stereotypes/',
-        'conversation_url': conversation.get_absolute_url(),
-    }
+    if conversation.is_promoted:
+        clusterization = conversation.get_clusterization(None)
+        stereotypes = () if clusterization is None else clusterization.stereotypes.all()
+        return {
+            'content_title': _('Stereotypes'),
+            'conversation_title': conversation.title,
+            'stereotypes': stereotypes,
+            'stereotype_url': conversation.get_absolute_url() + 'stereotypes/',
+            'conversation_url': conversation.get_absolute_url(),
+        }
+    else:
+        raise Http404
 
 
 @urlpatterns.route('conversations/<model:conversation>/stereotypes/add/',

--- a/src/ej_conversations/jinja2/ej_conversations/detail.jinja2
+++ b/src/ej_conversations/jinja2/ej_conversations/detail.jinja2
@@ -166,7 +166,7 @@
                                 {# FIXME Add a less hardcoded pluralization  #}
                                 {{ _("You have {} comment{} under moderation.").format(comments_under_moderation, "" if comments_under_moderation == 1 else "s")}}
                                 {% if comments_under_moderation > 0 %}
-                                    {{ link(_('Click here'), href='/profile/') }}
+                                    {{ link(_('Click here'), href='profile:detail') }}
                                     {{ _("to see {}.").format("it" if comments_under_moderation == 1 else "them") }}
                                 {% endif %}
                             </p>

--- a/src/ej_conversations/jinja2/ej_conversations/edit.jinja2
+++ b/src/ej_conversations/jinja2/ej_conversations/edit.jinja2
@@ -42,12 +42,17 @@
                 <p><i class="fa fa-list-ul"></i> <span>{{ board.title }}</span></p>
             {% endif %}
           </div>
-
-          <p style="text-align: center;">{{ action_button(_('Manage stereotypes'),
-                                          href='cluster:stereotype-list',
-                                          url_args={'conversation': conversation},
-                                          primary=False) }}</p>
-
+          {% if board %}
+              <p style="text-align: center;">{{ action_button(_('Manage stereotypes'),
+                                              href='boards:conversation-stereotype-list',
+                                              url_args={'board': board, 'conversation': conversation},
+                                              primary=False) }}</p>
+          {% else %}
+              <p style="text-align: center;">{{ action_button(_('Manage stereotypes'),
+                                              href='cluster:stereotype-list',
+                                              url_args={'conversation': conversation},
+                                              primary=False) }}</p>
+          {% endif %}
           {% if can_promote_conversation %}
               <p class="ConversationEdit-promote">
                 {% if conversation.is_promoted %}

--- a/src/ej_conversations/models/conversation.py
+++ b/src/ej_conversations/models/conversation.py
@@ -163,6 +163,14 @@ class Conversation(TimeStampedModel):
 
     def get_url(self, which, **kwargs):
         kwargs['conversation'] = self
+        from ej_boards.models import BoardSubscription
+        subscription = BoardSubscription.objects.filter(conversation=self)
+        if subscription.exists():
+            board = subscription[0].board
+            kwargs['board'] = board
+            which = 'boards:conversation-' + which.split(":", 1)[1]
+            print(which)
+            return SafeUrl(which, **kwargs)
         return SafeUrl(which, **kwargs)
 
     def get_anchor(self, name, which, **kwargs):

--- a/src/ej_conversations/roles.py
+++ b/src/ej_conversations/roles.py
@@ -6,6 +6,7 @@ from boogie import rules
 
 from ej.roles import with_template
 from . import models
+from ej_boards.models import BoardSubscription
 
 
 #
@@ -20,9 +21,13 @@ def conversation_card(conversation, request=None, url=None, **kwargs):
     user = getattr(request, 'user', None)
     can_moderate = user.has_perm('ej.can_moderate_conversation', conversation)
     tag = conversation.tags.first()  # only first is shown in card to prevent overflow
+    subscription = BoardSubscription.objects.filter(conversation=conversation)
+    board = None
+    if subscription.exists():
+        board = subscription[0].board
     return {
         'conversation': conversation,
-        'url': url or conversation.get_absolute_url(),
+        'url': url or conversation.get_absolute_url(board),
         'tag': tag,
         'n_comments': conversation.approved_comments.count(),
         'n_votes': conversation.votes.count(),

--- a/src/ej_conversations/routes/admin.py
+++ b/src/ej_conversations/routes/admin.py
@@ -31,7 +31,7 @@ def edit(request, conversation):
     return get_conversation_edit_context(request, conversation)
 
 
-def get_conversation_edit_context(request, conversation):
+def get_conversation_edit_context(request, conversation, board=None):
     if request.method == 'POST':
         form = forms.ConversationForm(
             data=request.POST,
@@ -50,6 +50,7 @@ def get_conversation_edit_context(request, conversation):
         'tags': ",".join(tags),
         'can_promote_conversation': request.user.has_perm('can_publish_promoted'),
         'comments': list(conversation.comments.filter(status='pending')),
+        'board': board,
     }
 
 

--- a/src/ej_conversations/routes/admin.py
+++ b/src/ej_conversations/routes/admin.py
@@ -82,7 +82,6 @@ def get_conversation_moderate_context(request, conversation):
     return {
         'conversation': conversation,
         'comment_status': status,
-        'edit_url': conversation.get_absolute_url() + 'edit/',
         'comments': list(conversation.comments.filter(status=status)),
         'tags': tags,
     }


### PR DESCRIPTION
# Descrição
- Correção da página /profile/boards/ que estava usando url absoluta de board
- Correção do link do card de conversa para conversas em boards
- Correção do link de perfil do usuário no detalhe da conversa (estava /profile/)
- Correção do link do botão edit na página de moderate da conversa, para referenciar corretamente a board
- Correção da página de esteriótipos de uma conversa de board, que não é mais acessada pelas urls como conversa promovida
- Correção da referência dos botões dos esteriótipos para que consigam referenciar conversas em boards e conversas promovidas

## Issues Relacionadas
resolves: #683 

## Checklist  
- [x] Os commits seguem o padrão do projeto (Flake8 e afins)
- [x] Os testes estão passando e cobrem as mudanças 
- [x] Marcou no título do pull request se ele é work in progress [WIP] ou se está pronto para revisão [REVIEW]
