### PR TITLE
[REVIEW] Padrão botão done

### DIFF
--- a/lib/scss/4_elements/_buttons.scss
+++ b/lib/scss/4_elements/_buttons.scss
@@ -55,4 +55,7 @@ $button-vpadding: $spacing-unit-tiny + 2px !default;
         font-size: $font-size-large;
         padding: (2 * $button-vpadding) (2 * $button-hpadding);
     }
+    &-done{
+        background-color: $color-accent;
+    }
 }

--- a/lib/scss/6_components/_clusters.scss
+++ b/lib/scss/6_components/_clusters.scss
@@ -13,7 +13,7 @@
         margin: 30px auto 0 auto;
         h1 {
             font-size: $font-size-huge;
-            color: $color-accent;;
+            color: $color-accent;
             font-weight: 300;
         }
         p {

--- a/src/ej_clusters/jinja2/ej_clusters/stereotype-list.jinja2
+++ b/src/ej_clusters/jinja2/ej_clusters/stereotype-list.jinja2
@@ -25,11 +25,11 @@
             <p>{% trans %}No stereotypes found{% endtrans %}</p>
         {% endif %}
 
-        <p style="text-align: center">
+        <p style="text-align: center" >
             <a class="Button" href="{{ stereotype_url }}add/">
                 <i class="fa fa-plus-circle"></i> {{ _('New stereotype') }}</a>
             <br>
-            {{ action_button(_('Done'), conversation_url) }}
+            {{ action_button(_('Done'), conversation_url).add_class('Button-done')}}
         </p>
     </div>
 {% endblock %}


### PR DESCRIPTION
# Descrição
  Botão concluir da tela de criação de estereótipos está fora do padrão css

## Issues Relacionadas
  #681 

## Checklist  
- [ ] Os commits seguem o padrão do projeto (Flake8 e afins)
- [ ] Os testes estão passando e cobrem as mudanças 
- [ ] Marcou no título do pull request se ele é work in progress [WIP] ou se está pronto para revisão [REVIEW]

## Imagens/Comentários
Antes
![49462511-5cb50380-f7dd-11e8-968e-4856f0bf8b53](https://user-images.githubusercontent.com/38738836/49816925-15d38a80-fd56-11e8-9b9c-9e35c3254c77.jpg)
Depois
![49462529-663e6b80-f7dd-11e8-9999-f99052c2f2ba](https://user-images.githubusercontent.com/38738836/49816933-1b30d500-fd56-11e8-8ec4-03d9d639531d.jpg)


