### PR TITLE
[REVIEW] Nome obtido das redes sociais está incorreto

### DIFF
--- a/src/ej_profiles/jinja2/ej_profiles/detail.jinja2
+++ b/src/ej_profiles/jinja2/ej_profiles/detail.jinja2
@@ -8,7 +8,7 @@
     <div class="Profile">
         <img class="Profile-image" src="{{ profile.image_url }}" alt="{{_('Profile picture')}}">
 
-        <h1>{{ profile.name }}</h1>
+        <h1>{{ profile.user }}</h1>
         {{ comments|role('collapsible-list', title=_('Comments'), item_role='list-item') }}
         {{ conversations|role('collapsible-list', title=_('Favorite Conversations'), item_role='card') }}
 

--- a/src/ej_users/socialbuttons.py
+++ b/src/ej_users/socialbuttons.py
@@ -51,6 +51,11 @@ def facebook_button(request):
     query = {
         'next': request.GET.get('next', '/conversations/'),
         'method': 'oauth2',
+        'fields': [
+            'name',
+            'first_name',
+            'last_name',
+        ]
     }
     url = provider.get_login_url(request, **query)
     return fa_icon('facebook', href=url, id='facebook-button', aria_label="Facebook Icon",


### PR DESCRIPTION
# Descrição
  Existem duas possibilidades, o nome não está sendo exibido pois não estamos chamando da forma correta, então troquei o profile.name para profile.user, o django allauth deve ser capaz de exibir o nome corretamente, ou, não estamos requisitando o field name para o Facebook na query do social button, o qual adicionei também.
## Issues Relacionadas
  resolves: #732

## Checklist  
- [x] Os commits seguem o padrão do projeto (Flake8 e afins)
- [x] Os testes estão passando e cobrem as mudanças 
- [x] Marcou no título do pull request se ele é work in progress [WIP] ou se está pronto para revisão [REVIEW]
