### PR TITLE
[REVIEW] Fix vote when user change skip choice

### DIFF
--- a/src/ej_conversations/api.py
+++ b/src/ej_conversations/api.py
@@ -1,5 +1,6 @@
 from boogie.rest import rest_api
 from ej_conversations.models import Conversation
+from ej_conversations.models.vote import Vote
 
 
 #
@@ -42,6 +43,16 @@ def statistics(conversation):
 def save_vote(request, vote):
     user = request.user
 
+    try:
+        skipped_vote = Vote.objects.get(
+            comment=vote.comment,
+            choice=0,
+            author=user)
+        skipped_vote.choice = vote.choice
+        skipped_vote.save()
+        return skipped_vote
+    except Exception:
+        pass
     if vote.id is None:
         vote.author = user
         vote.save()


### PR DESCRIPTION
# Descrição
 Atualmente quando um comentário é pulado pelo usuário, a api do EJ irá retornar esse comentário para que o usuário vote nele novamente. Quando o usuário realiza o voto a api quebra, pois não entende que esse voto já existe no banco e que precisa apenas ser atualizado com a nova escolha.

## Issues Relacionadas
 Como o bug foi identificado e logo corrigido, não há issue relacionada.
## Checklist  
- [ ] Os commits seguem o padrão do projeto (Flake8 e afins)
- [ ] Os testes estão passando e cobrem as mudanças 
- [ ] Marcou no título do pull request se ele é work in progress [WIP] ou se está pronto para revisão [REVIEW]

